### PR TITLE
Add `AGENTS.md` project plan for "Wetter vs. Klima" MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md – Projektplan "Wetter vs. Klima"
+
+Dieses Repository wird als Basis für eine erste Version einer Android-App (optional auch als einfache Web-App) genutzt, die aktuelle Wetterdaten mit historischen Klimamitteln vergleicht.
+
+## Zielbild (MVP)
+
+Wir bauen eine App/Webseite, die:
+
+1. den aktuellen Standort nutzt (oder manuell einen Ort/eine Region wählen lässt),
+2. Temperatur- und Niederschlagsverlauf für den letzten Monat und das letzte Jahr zeigt,
+3. den Verlauf dem historischen Klimamittel einer Referenzperiode (z. B. 1961–1990) für dieselbe Region gegenüberstellt,
+4. die Abweichung klar visualisiert ("heute vs. früher").
+
+## Produktidee (später)
+
+- Monetarisierung über Werbung
+- Gamification: "Schätze, wie viel wärmer/trockener als früher"
+- Soziale Komponente: Vergleich/Challenges mit Menschen aus derselben Region
+
+## Nächste Schritte (Roadmap)
+
+### 1) Repository aufräumen
+
+- Bestehende Dateien sichten (Daten, Frontend, Server)
+- Altlasten dokumentieren
+- Struktur für App + API + Daten vorbereiten
+
+### 2) Datenquellen festlegen
+
+- Öffentliche Wetter-/Klimadatenbank auswählen
+- Für den Start pragmatisch: erst ein frei verfügbares Open-Source-Griddatenset nutzen (auch wenn es ungenauer ist).
+- Optional später für höhere Genauigkeit: Mapping auf konkrete Wetterstation(en).
+- Prüfen:
+  - Standortauflösung (Koordinaten → Gridzelle; später optional nächste Station)
+  - Historische Referenzzeiträume: standardmäßig 1961–1990, perspektivisch zusätzlich auswählbar
+  - API-Limits und Lizenzbedingungen (bevorzugt zunächst Quellen ohne harte Limits; skalierbare APIs später)
+
+### 3) Erstes technisches Gerüst
+
+- Gemeinsame Datenzugriffsschicht definieren
+- Für MVP zuerst einfache Web-Ansicht oder Android-Basisansicht mit:
+  - Standortfreigabe oder manuelle Ortswahl
+  - zwei Diagrammen (Temperatur/Niederschlag)
+  - Vergleichslinie historisches Mittel
+
+### 4) Visualisierung & Kennzahlen
+
+- Monats-/Jahresansicht umschaltbar
+- Abweichungsmetriken festlegen (z. B. Δ Temperatur in °C, Δ Niederschlag in %)
+- Zusätzlich zu den Plots jeweils eine einfache Textmetrik anzeigen (z. B. "+1,8 °C vs. 1961–1990", "-12 % Niederschlag")
+- Aussagekräftige Farben/Legenden für "normal" vs. "abweichend"
+
+### 5) Vorbereitung auf spätere Features
+
+- Architektur so wählen, dass Werbung/Gamification/Social später ergänzt werden kann
+- Nutzerkonto nur optional und erst in späterer Phase
+
+## Arbeitsprinzipien
+
+- Erst funktionierender, kleiner MVP
+- Datenqualität und Quellen-Transparenz vor Feature-Menge
+- Jede neue Funktion mit kurzer Doku im Repo festhalten
+
+## Definition of Done (für den MVP-Start)
+
+- Standort kann ermittelt werden oder Ort/Region manuell gesetzt werden
+- Letzter Monat + letztes Jahr für Temperatur/Niederschlag abrufbar
+- Historisches Mittel derselben Region (standardmäßig 1961–1990) eingeblendet
+- Abweichung verständlich visualisiert (Plot + kurze Textmetrik)


### PR DESCRIPTION
### Motivation

- Provide a repository-level project plan and roadmap that defines the MVP scope for a "Wetter vs. Klima" app comparing current weather to historical climate.
- Capture decisions about data sources, visualization requirements, and future extension points to guide initial development and coordination.

### Description

- Add new `AGENTS.md` containing the project vision, MVP requirements, roadmap, data-source considerations, visualization and metric specifications, and a Definition of Done.
- Document planned next steps including repository cleanup, selecting open gridded datasets (with fallback to station mapping later), a minimal web/Android technical skeleton, and UI components for temperature and precipitation comparisons.
- Include working principles, monetization/feature ideas for later phases, and the default historical reference period `1961–1990`.

### Testing

- No automated tests were applicable to this documentation-only change.
- No CI test runs were required for adding `AGENTS.md` and none were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c32b57048329b6d3ac0369a31f2e)