### PR TITLE
Cap Open-Meteo archive requests to yesterday (UTC)

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,9 +98,16 @@
       return sums.map((s, i) => counts[i] ? Number((s / counts[i]).toFixed(2)) : null);
     }
 
-    async function fetchOpenMeteoYear(lat, lon, year) {
+    function toIsoDateUTC(d) {
+      const y = d.getUTCFullYear();
+      const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+      const day = String(d.getUTCDate()).padStart(2, '0');
+      return `${y}-${m}-${day}`;
+    }
+
+    async function fetchOpenMeteoYear(lat, lon, year, maxEndDate) {
       const start = `${year}-01-01`;
-      const end = `${year}-12-31`;
+      const end = maxEndDate && maxEndDate < `${year}-12-31` ? maxEndDate : `${year}-12-31`;
       const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lon}&start_date=${start}&end_date=${end}&daily=temperature_2m_mean&timezone=auto`;
       const r = await fetch(url);
       if (!r.ok) throw new Error(`Open-Meteo failed (${r.status})`);
@@ -135,10 +142,13 @@
         const now = new Date();
         const lastYear = now.getUTCFullYear() - 1;
         const currentYear = now.getUTCFullYear();
+        // Open-Meteo archive does not provide future dates.
+        const yesterdayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+        const maxEndDate = toIsoDateUTC(yesterdayUtc);
 
         const [yLast, yCurrent] = await Promise.all([
-          fetchOpenMeteoYear(lat, lon, lastYear),
-          fetchOpenMeteoYear(lat, lon, currentYear)
+          fetchOpenMeteoYear(lat, lon, lastYear, maxEndDate),
+          fetchOpenMeteoYear(lat, lon, currentYear, maxEndDate)
         ]);
 
         const climMean = mean(climateSeries.values);


### PR DESCRIPTION
### Motivation
- Prevent the Open-Meteo archive requests from including future dates which the archive does not provide and can cause missing-data errors.
- Ensure the current-year and last-year data fetches are capped to the latest available UTC date to avoid inconsistent results across timezones.

### Description
- Added a helper `toIsoDateUTC` to format a `Date` as an ISO `YYYY-MM-DD` string using UTC components.
- Extended `fetchOpenMeteoYear` to accept a `maxEndDate` parameter and clamp the `end_date` to `maxEndDate` when it is earlier than `YYYY-12-31`.
- In `run` compute `yesterdayUtc` using `Date.UTC` and pass its ISO date as `maxEndDate` into the Open-Meteo fetches for the last and current year.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cba8f71483299edd6352237715da)