### PR TITLE
Add GitHub Actions workflow to auto-deploy GitHub Pages on pushes to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,26 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
### Motivation
- Ensure the published GitHub Pages site is refreshed automatically after changes are merged by deploying the repository content to `gh-pages` whenever `main` is updated.

### Description
- Add a new workflow file at `.github/workflows/deploy-pages.yml` that triggers on pushes to `main` and on `workflow_dispatch`, and uses `peaceiris/actions-gh-pages@v4` to publish the repository root (`.`) to the `gh-pages` branch with `force_orphan: true` and `contents: write` permissions.

### Testing
- Validated the workflow file contents with `nl -ba .github/workflows/deploy-pages.yml` and confirmed it declares the expected triggers and action configuration (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d10947fc8329ace7986e02b6db2a)