### PR TITLE
Add 1961–1990 climate mean + rainfall comparison charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Use GitHub Pages directly after pushing this repository.
   - adjust by clicking/dragging marker on map,
   - optionally replace with precise browser GPS.
 - Open-Meteo archive API is queried with selected `latitude`/`longitude`.
+- Charts include:
+  - Temperature: current year monthly means vs 30-year climate mean (1961-1990).
+  - Rainfall: current year monthly totals vs 30-year monthly rainfall mean (1961-1990).

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     #map { height: 420px; margin-top: 1rem; border-radius: 8px; }
     #result { margin-top: 1rem; }
     #metrics { margin: 1rem 0; font-weight: 600; }
+    .chart-block { margin-top: 1rem; }
     canvas { max-width: 960px; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -19,7 +20,7 @@
 </head>
 <body>
   <h1>Weather vs Climate</h1>
-  <p>Frontend-only prototype using Open-Meteo APIs only. Pick a location on the map (starts with approximate network location), then compare monthly means for last year vs current year.</p>
+  <p>Frontend-only prototype using Open-Meteo APIs only. Pick a location on the map (starts with approximate network location), then compare current values with the 30-year climate mean (1961-1990).</p>
 
   <div class="row">
     <button id="use-gps-btn">Use precise browser GPS</button>
@@ -29,10 +30,17 @@
   <div id="map"></div>
   <div id="result"></div>
   <div id="metrics"></div>
-  <canvas id="tempChart"></canvas>
+
+  <div class="chart-block">
+    <canvas id="tempChart"></canvas>
+  </div>
+  <div class="chart-block">
+    <canvas id="rainChart"></canvas>
+  </div>
 
   <script>
-    let chartInstance = null;
+    let tempChartInstance = null;
+    let rainChartInstance = null;
     let map;
     let marker;
     let selectedLat = 52.52;
@@ -45,34 +53,89 @@
       return `${y}-${m}-${day}`;
     }
 
-    function yearMonthlyFromDaily(daily) {
-      const sums = new Array(12).fill(0);
-      const counts = new Array(12).fill(0);
-      daily.time.forEach((d, i) => {
-        const m = Number(d.slice(5, 7)) - 1;
-        const t = daily.temperature_2m_mean[i];
-        if (Number.isFinite(t) && m >= 0 && m < 12) {
-          sums[m] += t;
-          counts[m] += 1;
-        }
-      });
-      return sums.map((s, i) => counts[i] ? Number((s / counts[i]).toFixed(2)) : null);
-    }
-
     function mean(arr) {
       const v = arr.filter(Number.isFinite);
       return v.length ? v.reduce((a,b) => a+b, 0) / v.length : null;
     }
 
-    async function fetchOpenMeteoYear(lat, lon, year, maxEndDate) {
-      const start = `${year}-01-01`;
-      const end = maxEndDate && maxEndDate < `${year}-12-31` ? maxEndDate : `${year}-12-31`;
-      const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lon}&start_date=${start}&end_date=${end}&daily=temperature_2m_mean&timezone=auto`;
+    function monthLabels() {
+      return ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    }
+
+    async function fetchOpenMeteoDaily(lat, lon, startDate, endDate) {
+      const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lon}&start_date=${startDate}&end_date=${endDate}&daily=temperature_2m_mean,precipitation_sum&timezone=auto`;
       const r = await fetch(url);
       if (!r.ok) throw new Error(`Open-Meteo failed (${r.status})`);
       const data = await r.json();
-      if (!data.daily?.time || !data.daily?.temperature_2m_mean) throw new Error('Open-Meteo daily data missing');
-      return yearMonthlyFromDaily(data.daily);
+      if (!data.daily?.time || !data.daily?.temperature_2m_mean || !data.daily?.precipitation_sum) {
+        throw new Error('Open-Meteo daily data missing');
+      }
+      return data.daily;
+    }
+
+    function currentYearMonthlyFromDaily(daily) {
+      const tempSums = new Array(12).fill(0);
+      const tempCounts = new Array(12).fill(0);
+      const rainMonthly = new Array(12).fill(0);
+
+      daily.time.forEach((dateStr, i) => {
+        const m = Number(dateStr.slice(5, 7)) - 1;
+        if (m < 0 || m > 11) return;
+
+        const t = daily.temperature_2m_mean[i];
+        if (Number.isFinite(t)) {
+          tempSums[m] += t;
+          tempCounts[m] += 1;
+        }
+
+        const p = daily.precipitation_sum[i];
+        if (Number.isFinite(p)) {
+          rainMonthly[m] += p;
+        }
+      });
+
+      return {
+        tempMonthlyMean: tempSums.map((s, i) => tempCounts[i] ? Number((s / tempCounts[i]).toFixed(2)) : null),
+        rainMonthlyTotal: rainMonthly.map((v) => Number(v.toFixed(2)))
+      };
+    }
+
+    function climateMean1961To1990FromDaily(daily) {
+      const tempSums = new Array(12).fill(0);
+      const tempCounts = new Array(12).fill(0);
+
+      const rainByYearMonth = new Map();
+
+      daily.time.forEach((dateStr, i) => {
+        const year = Number(dateStr.slice(0, 4));
+        const month = Number(dateStr.slice(5, 7)) - 1;
+        if (month < 0 || month > 11) return;
+
+        const t = daily.temperature_2m_mean[i];
+        if (Number.isFinite(t)) {
+          tempSums[month] += t;
+          tempCounts[month] += 1;
+        }
+
+        const p = daily.precipitation_sum[i];
+        if (Number.isFinite(p)) {
+          const key = `${year}-${month}`;
+          rainByYearMonth.set(key, (rainByYearMonth.get(key) || 0) + p);
+        }
+      });
+
+      const rainMonthSums = new Array(12).fill(0);
+      const rainMonthCounts = new Array(12).fill(0);
+      for (const [key, total] of rainByYearMonth.entries()) {
+        const month = Number(key.split('-')[1]);
+        rainMonthSums[month] += total;
+        rainMonthCounts[month] += 1;
+      }
+
+      return {
+        tempMonthlyMean: tempSums.map((s, i) => tempCounts[i] ? Number((s / tempCounts[i]).toFixed(2)) : null),
+        rainMonthlyMeanTotal: rainMonthSums.map((s, i) => rainMonthCounts[i] ? Number((s / rainMonthCounts[i]).toFixed(2)) : null)
+      };
     }
 
     function updateSelectionText(sourceLabel) {
@@ -126,38 +189,54 @@
     async function runComparison() {
       const metrics = document.getElementById('metrics');
       metrics.textContent = '';
-      if (chartInstance) chartInstance.destroy();
+      if (tempChartInstance) tempChartInstance.destroy();
+      if (rainChartInstance) rainChartInstance.destroy();
 
       const now = new Date();
-      const lastYear = now.getUTCFullYear() - 1;
       const currentYear = now.getUTCFullYear();
       const yesterdayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
-      const maxEndDate = toIsoDateUTC(yesterdayUtc);
+      const currentYearStart = `${currentYear}-01-01`;
+      const currentYearEnd = toIsoDateUTC(yesterdayUtc);
 
       try {
-        const [yLast, yCurrent] = await Promise.all([
-          fetchOpenMeteoYear(selectedLat, selectedLon, lastYear, maxEndDate),
-          fetchOpenMeteoYear(selectedLat, selectedLon, currentYear, maxEndDate)
+        const [currentDaily, climateDaily] = await Promise.all([
+          fetchOpenMeteoDaily(selectedLat, selectedLon, currentYearStart, currentYearEnd),
+          fetchOpenMeteoDaily(selectedLat, selectedLon, '1961-01-01', '1990-12-31')
         ]);
 
-        const curMean = mean(yCurrent);
-        const lastMean = mean(yLast);
-        const delta = (Number.isFinite(lastMean) && Number.isFinite(curMean)) ? (curMean - lastMean) : null;
+        const current = currentYearMonthlyFromDaily(currentDaily);
+        const climate = climateMean1961To1990FromDaily(climateDaily);
+
+        const curMean = mean(current.tempMonthlyMean);
+        const climateMean = mean(climate.tempMonthlyMean);
+        const delta = (Number.isFinite(climateMean) && Number.isFinite(curMean)) ? (curMean - climateMean) : null;
 
         metrics.textContent = delta === null
           ? 'Delta unavailable'
-          : `${currentYear} vs ${lastYear}: ${delta >= 0 ? '+' : ''}${delta.toFixed(2)} °C`;
+          : `${currentYear} vs climate mean 1961-1990: ${delta >= 0 ? '+' : ''}${delta.toFixed(2)} °C`;
 
-        chartInstance = new Chart(document.getElementById('tempChart'), {
+        tempChartInstance = new Chart(document.getElementById('tempChart'), {
           type: 'line',
           data: {
-            labels: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+            labels: monthLabels(),
             datasets: [
-              { label: `${lastYear} (Open-Meteo)`, data: yLast, borderColor: '#f4a261', tension: .2 },
-              { label: `${currentYear} (Open-Meteo)`, data: yCurrent, borderColor: '#e76f51', tension: .2 }
+              { label: '1961-1990 monthly mean (Open-Meteo)', data: climate.tempMonthlyMean, borderColor: '#457b9d', tension: .2 },
+              { label: `${currentYear} monthly mean (Open-Meteo)`, data: current.tempMonthlyMean, borderColor: '#e76f51', tension: .2 }
             ]
           },
-          options: { responsive: true, scales: { y: { title: { display: true, text: '°C' } } } }
+          options: { responsive: true, plugins: { title: { display: true, text: 'Temperature: Current Year vs 1961-1990 Mean' } }, scales: { y: { title: { display: true, text: '°C' } } } }
+        });
+
+        rainChartInstance = new Chart(document.getElementById('rainChart'), {
+          type: 'line',
+          data: {
+            labels: monthLabels(),
+            datasets: [
+              { label: '1961-1990 monthly rainfall mean (Open-Meteo)', data: climate.rainMonthlyMeanTotal, borderColor: '#264653', tension: .2 },
+              { label: `${currentYear} monthly rainfall total (Open-Meteo)`, data: current.rainMonthlyTotal, borderColor: '#2a9d8f', tension: .2 }
+            ]
+          },
+          options: { responsive: true, plugins: { title: { display: true, text: 'Rainfall: Current Year vs 1961-1990 Mean' } }, scales: { y: { title: { display: true, text: 'mm' } } } }
         });
       } catch (e) {
         document.getElementById('result').textContent = `Error: ${e.message}`;


### PR DESCRIPTION
### Motivation
- Provide a 30-year climate baseline (1961–1990) to compare current-year temperature against a standard climatology instead of only comparing to the previous year.
- Add precipitation comparison to show how current-year monthly rainfall totals compare to the 1961–1990 monthly rainfall mean.
- Keep the prototype frontend-only and coordinate-driven using Open-Meteo archive data.

### Description
- `index.html`: extended the Open-Meteo fetch to include `temperature_2m_mean` and `precipitation_sum` and added `fetchOpenMeteoDaily` to retrieve daily data for arbitrary date ranges.
- `index.html`: added aggregation routines `currentYearMonthlyFromDaily` and `climateMean1961To1990FromDaily` to compute monthly temperature means and rainfall totals/means from daily arrays.
- `index.html`: added two Chart.js charts (`tempChart` and `rainChart`) to render temperature (current year vs 1961–1990 mean) and rainfall (current year totals vs 1961–1990 monthly mean), and updated the metric text to show the temperature delta vs the 1961–1990 mean.
- `README.md`: updated to document the new chart outputs (temperature and rainfall comparisons vs 1961–1990).

### Testing
- Ran automated repository checks and file inspections: `rg --files`, `nl -ba index.html`, and `nl -ba README.md`, and committed the changes with `git commit` which completed successfully.
- No unit tests are present in the project; changes were smoke-tested via the automated file/commit checks above and reviewed for correct data flow and chart wiring (no runtime JS tests executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d6b5f0248329b8d1aca8d5cc163b)