### PR TITLE
Add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Then open: <http://localhost:8080>
 Option 2:
 Use GitHub Pages directly after pushing this repository.
 
+GitHub Pages link (replace `<username>` with your GitHub username):
+<https://<username>.github.io/weathervsclimate/>
+
 ## Notes
 
 - Frontend-only architecture.


### PR DESCRIPTION
### Motivation
- Make it easy to find the hosted GitHub Pages site by adding a direct placeholder link to the README.

### Description
- Updated `README.md` under the "Option 2" section to add the placeholder URL `https://<username>.github.io/weathervsclimate/`.

### Testing
- Verified the change with `nl -ba README.md | sed -n '1,80p'` and checked repository state with `git status --short`, both showing the new content and a committed change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dd9c19488329bda8c04fe7765785)