### PR TITLE
Update README: Add clickable GitHub Pages URL for jan-rybizki

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Then open: <http://localhost:8080>
 Option 2:
 Use GitHub Pages directly after pushing this repository.
 
-GitHub Pages link (replace `<username>` with your GitHub username):
-<https://<username>.github.io/weathervsclimate/>
+GitHub Pages link:
+<https://jan-rybizki.github.io/weathervsclimate/>
 
 ## Notes
 


### PR DESCRIPTION
### Motivation
- Replace the placeholder GitHub Pages URL with the actual username so the README provides a direct clickable project site link.

### Description
- Updated `README.md` to replace `<https://<username>.github.io/weathervsclimate/>` with `https://jan-rybizki.github.io/weathervsclimate/` and kept the autolink format.

### Testing
- Ran `git diff -- README.md`, `git commit -m "Update README with Jan's clickable GitHub Pages URL"`, and verified the lines with `nl -ba README.md | sed -n '14,24p'`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e07c918083299a2c7a7be7e9260f)