### PR TITLE
Fix Open-Meteo 400 by stopping archive requests at today

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
       const currentYear = now.getUTCFullYear();
       const years = [currentYear - 2, currentYear - 1, currentYear];
       const startStr = `${years[0]}-01-01`;
-      const endStr = `${years[2]}-12-31`;
+      const endStr = toIsoDateUTC(now);
 
       try {
         const [currentDaily, climateDaily] = await Promise.all([
@@ -276,7 +276,7 @@
         const climateRainMean = mean(climateRainForRange);
         const rainDeltaPercent = (Number.isFinite(climateRainMean) && climateRainMean !== 0 && Number.isFinite(curRainMean)) ? ((curRainMean - climateRainMean) / climateRainMean) * 100 : null;
 
-        metrics.textContent = `Comparing full years ${years[0]}, ${years[1]}, ${years[2]} (January to December; includes last 24+ months) with the 1961-1990 monthly mean.`;
+        metrics.textContent = `Comparing ${years[0]}-01-01 to ${endStr} with the 1961-1990 monthly mean (same coordinates).`;
         document.getElementById('tempYearDelta').textContent = tempDelta === null
           ? 'Mean Δ unavailable'
           : `Mean Δ: ${tempDelta >= 0 ? '+' : ''}${tempDelta.toFixed(2)} °C`;


### PR DESCRIPTION
### Motivation
- The Open-Meteo archive call used `end_date=${currentYear}-12-31`, which can include future dates and causes HTTP 400 responses from the archive endpoint.

### Description
- In `index.html` `runComparison()` now sets `endStr` to `toIsoDateUTC(now)` so the `end_date` is today's UTC date rather than the end of the current year.
- Updated the on-screen metrics text to show the actual requested range (`start` to `endStr`) so the UI no longer implies a full current-year request.
- Only the frontend `index.html` was changed and no server-side code was modified.

### Testing
- `git commit` for the change completed successfully. 
- A direct `curl` check to the Open-Meteo archive endpoint returned `000` in this environment, so live API validation could not be completed here. 
- A Python attempt using `requests` failed due to a missing `requests` module in the environment, so that path was not validated. 
- The PR metadata was created via the repository `make_pr` helper successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098099cfec832987982c1d662be4f3)