### PR TITLE
Set temperature chart y-axis to -5..25°C and make precipitation y-axis start at 0 with padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,10 +262,10 @@
       return ((s - b) / b) * 100;
     }
 
-    function computeAxisBounds(seriesList, padRatio = 0.08) {
+    function computeAxisBounds(seriesList, padRatio = 0.08, fixedMin = null) {
       const flat = seriesList.flat().filter(Number.isFinite);
       if (!flat.length) return undefined;
-      const min = Math.min(...flat);
+      const min = fixedMin === null ? Math.min(...flat) : fixedMin;
       const max = Math.max(...flat);
       if (min === max) {
         const pad = Math.max(1, Math.abs(min) * padRatio);
@@ -273,7 +273,7 @@
       }
       const span = max - min;
       const pad = span * padRatio;
-      return { min: Number((min - pad).toFixed(2)), max: Number((max + pad).toFixed(2)) };
+      return { min: Number(min.toFixed(2)), max: Number((max + pad).toFixed(2)) };
     }
 
     async function runComparison() {
@@ -330,8 +330,8 @@
         tempDatasets.push({ label: '1961-1990 Monatsmittel (zugeordnet)', data: climateTemp, borderColor: '#457b9d', borderDash:[5,5], tension:.2 });
         rainDatasets.push({ label: '1961-1990 Niederschlagsmittel (zugeordnet)', data: climateRain, borderColor: '#264653', borderDash:[5,5], tension:.2 });
 
-        const tempBounds = computeAxisBounds([current.temp, climateTemp]);
-        const rainBounds = computeAxisBounds([current.rain, climateRain]);
+        const tempBounds = { min: -5, max: 25 };
+        const rainBounds = computeAxisBounds([current.rain, climateRain], 0.08, 0);
 
         tempChartInstance = new Chart(document.getElementById('tempChart'), { type:'line', data:{ labels: current.labels, datasets: tempDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'🌡️ Temperatur: letzte 24 Monate'} }, scales:{ y:{ min:tempBounds?.min, max:tempBounds?.max, title:{display:true,text:'°C'} } } } });
         rainChartInstance = new Chart(document.getElementById('rainChart'), { type:'line', data:{ labels: current.labels, datasets: rainDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'💧 Niederschlag: letzte 24 Monate'} }, scales:{ y:{ min:rainBounds?.min, max:rainBounds?.max, title:{display:true,text:'mm'} } } } });


### PR DESCRIPTION
### Motivation
- Ensure the temperature plot uses a stable, comparable y-axis so users can read anomalies consistently across locations and times.
- Ensure the precipitation plot always starts at zero and auto-scales to the displayed maximum with a small buffer so bars/lines are not clipped.

### Description
- Set the temperature chart bounds to a fixed range of `-5` to `25` (°C) by using `tempBounds = { min: -5, max: 25 }` when building the Chart.js config. 
- Extended `computeAxisBounds` to accept an optional `fixedMin` parameter (`function computeAxisBounds(seriesList, padRatio = 0.08, fixedMin = null)`) and use `fixedMin` as the lower bound when provided. 
- For precipitation, call `computeAxisBounds([current.rain, climateRain], 0.08, 0)` so the y-axis lower bound is always `0` and the upper bound includes an ~8% padding above the maximum. 
- Adjusted axis padding behavior so the computed maximum receives padding while a provided `fixedMin` is honored exactly (rounded to 2 decimals).

### Testing
- Committed the change with `git add index.html && git commit -m "Adjust chart y-axis ranges for temperature and precipitation"`, and the commit succeeded. 
- Inspected the updated `index.html` sections with `nl`/`sed` to confirm the new `computeAxisBounds` signature and the hardcoded `tempBounds`. 
- Performed a basic syntax/preview check of the edited `index.html` and found no syntax errors (no automated unit tests are present in the repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0989b3ce5c8329904faedfeca20d84)