### PR TITLE
Default to latest 12 months and optionally show previous 12

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <span id="recent12Metrics" class="range-metrics">Δ zum Langzeitmittel: –</span>
     </div>
     <div class="range-item">
-      <label><input type="checkbox" id="togglePrev12" checked> 12–24 Monate zurück anzeigen</label>
+      <label><input type="checkbox" id="togglePrev12"> 12–24 Monate zurück anzeigen</label>
       <span id="prev12Metrics" class="range-metrics">Δ zum Langzeitmittel: –</span>
     </div>
   </div>
@@ -317,24 +317,35 @@
         const showRecent = document.getElementById('toggleRecent12').checked;
         const showPrev = document.getElementById('togglePrev12').checked;
 
+        const displayFrom = showPrev ? prevRange.from : recentRange.from;
+        const displayTo = recentRange.to;
+
+        function displaySlice(arr) { return arr.slice(displayFrom, displayTo); }
+
+        const labels = displaySlice(current.labels);
+        const displayTemp = displaySlice(current.temp);
+        const displayRain = displaySlice(current.rain);
+        const displayClimateTemp = displaySlice(climateTemp);
+        const displayClimateRain = displaySlice(climateRain);
+
         const tempDatasets = [];
         const rainDatasets = [];
         if (showRecent) {
-          tempDatasets.push({ label: 'Letzte 12 Monate Temperatur', data: current.temp.map((v,i)=> i>=recentRange.from ? v : null), borderColor: '#3a86ff', tension:.2 });
-          rainDatasets.push({ label: 'Letzte 12 Monate Niederschlag', data: current.rain.map((v,i)=> i>=recentRange.from ? v : null), borderColor: '#3a86ff', tension:.2 });
+          tempDatasets.push({ label: 'Letzte 12 Monate Temperatur', data: displayTemp.map((v,i)=> i>=Math.max(recentRange.from - displayFrom, 0) ? v : null), borderColor: '#3a86ff', tension:.2 });
+          rainDatasets.push({ label: 'Letzte 12 Monate Niederschlag', data: displayRain.map((v,i)=> i>=Math.max(recentRange.from - displayFrom, 0) ? v : null), borderColor: '#3a86ff', tension:.2 });
         }
         if (showPrev) {
-          tempDatasets.push({ label: '12-24 Monate zurück Temperatur', data: current.temp.map((v,i)=> (i>=prevRange.from && i<prevRange.to) ? v : null), borderColor: '#ff006e', tension:.2 });
-          rainDatasets.push({ label: '12-24 Monate zurück Niederschlag', data: current.rain.map((v,i)=> (i>=prevRange.from && i<prevRange.to) ? v : null), borderColor: '#ff006e', tension:.2 });
+          tempDatasets.push({ label: '12-24 Monate zurück Temperatur', data: displayTemp.map((v,i)=> i<Math.max(prevRange.to - displayFrom, 0) ? v : null), borderColor: '#ff006e', tension:.2 });
+          rainDatasets.push({ label: '12-24 Monate zurück Niederschlag', data: displayRain.map((v,i)=> i<Math.max(prevRange.to - displayFrom, 0) ? v : null), borderColor: '#ff006e', tension:.2 });
         }
-        tempDatasets.push({ label: '1961-1990 Monatsmittel (zugeordnet)', data: climateTemp, borderColor: '#457b9d', borderDash:[5,5], tension:.2 });
-        rainDatasets.push({ label: '1961-1990 Niederschlagsmittel (zugeordnet)', data: climateRain, borderColor: '#264653', borderDash:[5,5], tension:.2 });
+        tempDatasets.push({ label: '1961-1990 Monatsmittel (zugeordnet)', data: displayClimateTemp, borderColor: '#457b9d', borderDash:[5,5], tension:.2 });
+        rainDatasets.push({ label: '1961-1990 Niederschlagsmittel (zugeordnet)', data: displayClimateRain, borderColor: '#264653', borderDash:[5,5], tension:.2 });
 
         const tempBounds = { min: -5, max: 25 };
-        const rainBounds = computeAxisBounds([current.rain, climateRain], 0.08, 0);
+        const rainBounds = computeAxisBounds([displayRain, displayClimateRain], 0.08, 0);
 
-        tempChartInstance = new Chart(document.getElementById('tempChart'), { type:'line', data:{ labels: current.labels, datasets: tempDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'🌡️ Temperatur: letzte 24 Monate'} }, scales:{ y:{ min:tempBounds?.min, max:tempBounds?.max, title:{display:true,text:'°C'} } } } });
-        rainChartInstance = new Chart(document.getElementById('rainChart'), { type:'line', data:{ labels: current.labels, datasets: rainDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'💧 Niederschlag: letzte 24 Monate'} }, scales:{ y:{ min:rainBounds?.min, max:rainBounds?.max, title:{display:true,text:'mm'} } } } });
+        tempChartInstance = new Chart(document.getElementById('tempChart'), { type:'line', data:{ labels, datasets: tempDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'🌡️ Temperatur: ausgewählter Zeitraum'} }, scales:{ y:{ min:tempBounds?.min, max:tempBounds?.max, title:{display:true,text:'°C'} } } } });
+        rainChartInstance = new Chart(document.getElementById('rainChart'), { type:'line', data:{ labels, datasets: rainDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'💧 Niederschlag: ausgewählter Zeitraum'} }, scales:{ y:{ min:rainBounds?.min, max:rainBounds?.max, title:{display:true,text:'mm'} } } } });
 
         document.getElementById('tempYearDelta').textContent = recentTempDelta===null ? 'Δ (letzte 12M): –' : `Δ (letzte 12M): ${recentTempDelta>=0?'+':''}${recentTempDelta.toFixed(2)} °C`;
         document.getElementById('rainYearDelta').textContent = recentRainDelta===null ? 'Δ (letzte 12M): –' : `Δ (letzte 12M): ${recentRainDelta>=0?'+':''}${recentRainDelta.toFixed(1)} %`;


### PR DESCRIPTION
### Motivation
- Die Standardanzeige soll nur die letzten 12 Monate (bis einschließlich aktueller Monat) zeigen und nicht automatisch 24 Monate darstellen.
- Nutzer sollen optional die vorherigen 12 Monate (12–24 Monate zurück) einblenden können, ohne die Standardansicht zu verändern.

### Description
- Ändere die Checkbox in `index.html` so dass `12–24 Monate zurück anzeigen` standardmäßig **nicht** angehakt ist (Checkbox entfernt das `checked`-Attribut).
- Passe die Chart-Logik an: berechne `recentRange` und `prevRange`, bestimme `displayFrom`/`displayTo` und slice die Labels/Serien mit `displaySlice` sodass die X‑Achse nur den ausgewählten 12‑Monats‑Fenster (oder bei Aktivierung zusätzlich die vorherigen 12) zeigt.
- Schneide die Klima-Referenzserien (`climateTemp`/`climateRain`) auf den sichtbaren Zeitraum zu und aktualisiere Chart-Titel auf „ausgewählter Zeitraum".
- Behalte die Delta-Berechnungen und Metrik-Elemente bei, die weiterhin für die letzten 12 Monate bzw. 12–24 Monate berechnet und angezeigt werden.

### Testing
- Reviewed the diff for `index.html` with `git diff -- index.html && git status --short` and confirmed the intended changes succeeded. (command succeeded)
- Inspected the updated source region with `nl -ba index.html | sed -n '34,390p'` to verify the new slicing and chart construction logic. (command succeeded)
- Created a commit with `git add index.html && git commit -m "Default to latest 12 months and optionally show previous 12"` to record the change. (commit succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098ab24e7883299d178191ced53a7b)