### PR TITLE
Fold recent and previous 12-month series onto shared month axis

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,32 +317,29 @@
         const showRecent = document.getElementById('toggleRecent12').checked;
         const showPrev = document.getElementById('togglePrev12').checked;
 
-        const displayFrom = showPrev ? prevRange.from : recentRange.from;
-        const displayTo = recentRange.to;
-
-        function displaySlice(arr) { return arr.slice(displayFrom, displayTo); }
-
-        const labels = displaySlice(current.labels);
-        const displayTemp = displaySlice(current.temp);
-        const displayRain = displaySlice(current.rain);
-        const displayClimateTemp = displaySlice(climateTemp);
-        const displayClimateRain = displaySlice(climateRain);
+        const labels = monthLabels();
+        const foldedRecentTemp = sliceRange(current.temp, recentRange);
+        const foldedRecentRain = sliceRange(current.rain, recentRange);
+        const foldedRecentClimateTemp = sliceRange(climateTemp, recentRange);
+        const foldedRecentClimateRain = sliceRange(climateRain, recentRange);
+        const foldedPrevTemp = sliceRange(current.temp, prevRange);
+        const foldedPrevRain = sliceRange(current.rain, prevRange);
 
         const tempDatasets = [];
         const rainDatasets = [];
         if (showRecent) {
-          tempDatasets.push({ label: 'Letzte 12 Monate Temperatur', data: displayTemp.map((v,i)=> i>=Math.max(recentRange.from - displayFrom, 0) ? v : null), borderColor: '#3a86ff', tension:.2 });
-          rainDatasets.push({ label: 'Letzte 12 Monate Niederschlag', data: displayRain.map((v,i)=> i>=Math.max(recentRange.from - displayFrom, 0) ? v : null), borderColor: '#3a86ff', tension:.2 });
+          tempDatasets.push({ label: 'Letzte 12 Monate Temperatur', data: foldedRecentTemp, borderColor: '#3a86ff', tension:.2 });
+          rainDatasets.push({ label: 'Letzte 12 Monate Niederschlag', data: foldedRecentRain, borderColor: '#3a86ff', tension:.2 });
         }
         if (showPrev) {
-          tempDatasets.push({ label: '12-24 Monate zurück Temperatur', data: displayTemp.map((v,i)=> i<Math.max(prevRange.to - displayFrom, 0) ? v : null), borderColor: '#ff006e', tension:.2 });
-          rainDatasets.push({ label: '12-24 Monate zurück Niederschlag', data: displayRain.map((v,i)=> i<Math.max(prevRange.to - displayFrom, 0) ? v : null), borderColor: '#ff006e', tension:.2 });
+          tempDatasets.push({ label: '12-24 Monate zurück Temperatur', data: foldedPrevTemp, borderColor: '#ff006e', tension:.2 });
+          rainDatasets.push({ label: '12-24 Monate zurück Niederschlag', data: foldedPrevRain, borderColor: '#ff006e', tension:.2 });
         }
-        tempDatasets.push({ label: '1961-1990 Monatsmittel (zugeordnet)', data: displayClimateTemp, borderColor: '#457b9d', borderDash:[5,5], tension:.2 });
-        rainDatasets.push({ label: '1961-1990 Niederschlagsmittel (zugeordnet)', data: displayClimateRain, borderColor: '#264653', borderDash:[5,5], tension:.2 });
+        tempDatasets.push({ label: '1961-1990 Monatsmittel (zugeordnet)', data: foldedRecentClimateTemp, borderColor: '#457b9d', borderDash:[5,5], tension:.2 });
+        rainDatasets.push({ label: '1961-1990 Niederschlagsmittel (zugeordnet)', data: foldedRecentClimateRain, borderColor: '#264653', borderDash:[5,5], tension:.2 });
 
         const tempBounds = { min: -5, max: 25 };
-        const rainBounds = computeAxisBounds([displayRain, displayClimateRain], 0.08, 0);
+        const rainBounds = computeAxisBounds([foldedRecentRain, foldedPrevRain, foldedRecentClimateRain], 0.08, 0);
 
         tempChartInstance = new Chart(document.getElementById('tempChart'), { type:'line', data:{ labels, datasets: tempDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'🌡️ Temperatur: ausgewählter Zeitraum'} }, scales:{ y:{ min:tempBounds?.min, max:tempBounds?.max, title:{display:true,text:'°C'} } } } });
         rainChartInstance = new Chart(document.getElementById('rainChart'), { type:'line', data:{ labels, datasets: rainDatasets }, options:{ responsive:true, maintainAspectRatio:false, plugins:{ title:{display:true, text:'💧 Niederschlag: ausgewählter Zeitraum'} }, scales:{ y:{ min:rainBounds?.min, max:rainBounds?.max, title:{display:true,text:'mm'} } } } });


### PR DESCRIPTION
### Motivation
- Improve month-to-month comparison by folding the last 12 months and the prior 12–24 month window onto a shared Jan–Dec x-axis instead of plotting a continuous 24-month timeline.

### Description
- Replace the continuous 24-month display with fixed month labels via `monthLabels()` and create folded 12-point series using `sliceRange(...)` (`foldedRecent*` and `foldedPrev*`).
- Update the temperature and precipitation dataset construction to use the folded series while keeping the existing range toggles and delta metrics intact.
- Adjust precipitation axis bounds to include `foldedRecentRain`, `foldedPrevRain`, and `foldedRecentClimateRain` when computing y-axis limits.
- All changes are confined to `index.html` and only affect chart data preparation and rendering logic.

### Testing
- Applied an automated patch (Python script) that replaced the targeted block in `index.html` and printed `patched` to confirm the edit.
- Verified the modified code region with `git status --short && nl -ba index.html | sed -n '300,430p'` and successfully committed the change with `git commit`.
- No repository unit tests or automated browser-rendering tests exist, so no automated runtime/chart rendering tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099393d6e88329b071816a571c2526)