### PR TITLE
Load 24 months up front so 12–24 month toggle has data

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
 
       const now = new Date();
       const endStr = toIsoDateUTC(now);
-      const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 12, 1));
+      const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 24, 1));
       const startStr = toIsoDateUTC(start);
 
       try {
@@ -312,7 +312,7 @@
         document.getElementById('recent12Metrics').textContent = `ΔT: ${recentTempDelta===null?'–':`${recentTempDelta>=0?'+':''}${recentTempDelta.toFixed(2)} °C`} | ΔN: ${recentRainDelta===null?'–':`${recentRainDelta>=0?'+':''}${recentRainDelta.toFixed(1)} %`}`;
         document.getElementById('prev12Metrics').textContent = `ΔT: ${prevTempDelta===null?'–':`${prevTempDelta>=0?'+':''}${prevTempDelta.toFixed(2)} °C`} | ΔN: ${prevRainDelta===null?'–':`${prevRainDelta>=0?'+':''}${prevRainDelta.toFixed(1)} %`}`;
 
-        metrics.textContent = `Vergleich für ${startStr} bis ${endStr} (Standard: letzte 12 Monate) mit dem Langzeitmittel 1961-1990 (gleiche Koordinaten).`;
+        metrics.textContent = `Vergleich für ${startStr} bis ${endStr} (24 Monate geladen; Anzeige per Checkbox für letzte 12 bzw. 12–24 Monate) mit dem Langzeitmittel 1961-1990 (gleiche Koordinaten).`;
 
         const showRecent = document.getElementById('toggleRecent12').checked;
         const showPrev = document.getElementById('togglePrev12').checked;


### PR DESCRIPTION
### Motivation
- The "12–24 Monate zurück" series had no source data because the app only requested the last 12 months from Open‑Meteo, so the optional older 12‑month view could not render.

### Description
- Changed the current-period fetch window in `index.html` from `now - 12 months` to `now - 24 months` so the app preloads two years of monthly data for optional slicing. 
- Updated the UI metrics text to state that 24 months are loaded and that display is controlled by the checkboxes. 
- Left the existing chart/checkbox logic unchanged so the latest 12 months remain the default and the 12–24 month block appears only when enabled.

### Testing
- No automated test suite is present for this prototype; performed a code sanity review and file checks (diff/commit) after the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a14a64148329ac9c262e87ab8af2)